### PR TITLE
Add excluded workflows to df.py and cfr.py

### DIFF
--- a/cfr.py
+++ b/cfr.py
@@ -33,7 +33,9 @@ args = parser.parse_args()
 
 # load the repository names from a JSON file
 with open(args.filename, "r") as f:
-    repos = json.load(f)["repos"]
+    data = json.load(f)
+    repos = data['repos']
+    excluded_workflows = data['excluded_workflows']
 
 filename, file_extension = os.path.splitext(args.filename)
 # Initialize variables
@@ -54,7 +56,7 @@ for repo in repos:
     workflow_runs = get_workflow_runs(OWNER, repo, ACCESS_TOKEN, params)
     total_workflow_runs += len(workflow_runs)
     total_unsuccessful_runs += len(
-        [run for run in workflow_runs if run["conclusion"] != "success"]
+        [run for run in workflow_runs if run["conclusion"] != "success" and run["name"] not in excluded_workflows]
     )
 
 

--- a/df.py
+++ b/df.py
@@ -61,7 +61,7 @@ for repo in repos:
         # Log message if there's a problem retrieving the workflow runs
         print(f"Error retrieving workflow runs: {e}")
 
-# Calculate number of successful runs (minus the excluded runs)
+# Calculate number of successful runs (minus the excluded workflows)
 num_successful_runs += len(
     [run for run in runs if run["name"] not in excluded_workflows]
     )

--- a/df.py
+++ b/df.py
@@ -24,8 +24,6 @@ logger.addHandler(fh)
 # Initialize variables
 runs = []
 per_page = 100
-num_excluded_runs = 0
-
 date_format = "%Y-%m-%dT%H:%M:%SZ"
 
 # Read ACCESS_TOKEN from environment
@@ -64,11 +62,9 @@ for repo in repos:
         print(f"Error retrieving workflow runs: {e}")
 
 # Calculate number of successful runs (minus the excluded runs)
-num_runs = len(runs)
-num_excluded_runs += len(
-        [run for run in runs if run["name"] in excluded_workflows]
+num_successful_runs += len(
+    [run for run in runs if run["name"] not in excluded_workflows]
     )
-num_successful_runs = (num_runs - num_excluded_runs)
 
 # Compute the number of days between the earliest and latest successful runs
 if num_successful_runs > 0:

--- a/df.py
+++ b/df.py
@@ -24,6 +24,7 @@ logger.addHandler(fh)
 # Initialize variables
 runs = []
 per_page = 100
+num_excluded_runs = 0
 
 date_format = "%Y-%m-%dT%H:%M:%SZ"
 
@@ -42,7 +43,9 @@ filename, file_extension = os.path.splitext(args.filename)
 
 # load the repository names from a JSON file
 with open(args.filename, "r") as f:
-    repos = json.load(f)["repos"]
+    data = json.load(f)
+    repos = data['repos']
+    excluded_workflows = data['excluded_workflows']
 
 num_successful_runs = 0
 
@@ -60,7 +63,12 @@ for repo in repos:
         # Log message if there's a problem retrieving the workflow runs
         print(f"Error retrieving workflow runs: {e}")
 
-num_successful_runs = len(runs)
+# Calculate number of successful runs (minus the excluded runs)
+num_runs = len(runs)
+num_excluded_runs += len(
+        [run for run in runs if run["name"] in excluded_workflows]
+    )
+num_successful_runs = (num_runs - num_excluded_runs)
 
 # Compute the number of days between the earliest and latest successful runs
 if num_successful_runs > 0:


### PR DESCRIPTION
Adds a list of workflows to be excluded from the results in df.py and cfr.py as we discovered that these were skewing the stats.

I tested these locally and got:

```
❯ python3 cfr.py modernisation-platform.json 2024-05-23..2024-05-24
Total Workflow Runs: 136
Total Unsuccessful Runs: 0
Change Failure Rate for modernisation-platform: 0.00%
```

and 

```
❯ python3 df.py modernisation-platform.json 2024-05-23..2024-05-24
Daily deployment frequency for modernisation-platform: 47.00 deployments/day
```