### PR TITLE
Authenticate all DORA workflows via Octo STS (drop the PAT)

### DIFF
--- a/.github/workflows/cp-dora.yml
+++ b/.github/workflows/cp-dora.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       issues: write
       contents: read
+      id-token: write # required for the Octo STS OIDC exchange
     runs-on: ubuntu-latest
     # CP is ~150 repos of deployment/status/commit calls paced under the 5000/hr
     # core limit (~3h). Cap generously so a pathological run cannot hang forever.
@@ -30,6 +31,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Obtain Octo STS token
+        # Mints a short-lived, org-wide read token (replacing a long-lived PAT)
+        # to read code search, contents and deployments across ~150 Cloud
+        # Platform tenant repos. Requires the org-level trust policy in
+        # ministryofjustice/.github (.github/chainguard/ministryofjustice-dora-the-explora.sts.yaml).
+        id: octo_sts
+        uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        with:
+          scope: ministryofjustice
+          identity: ministryofjustice-dora-the-explora
 
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -49,7 +61,7 @@ jobs:
 
       - name: Run CP DORA and create an issue
         env:
-          ACCESS_TOKEN: ${{ secrets.DATA_PLATFORM_ROBOT_PAT }}
+          ACCESS_TOKEN: ${{ steps.octo_sts.outputs.token }}
           GH_TOKEN: ${{ github.token }}
           SINCE: ${{ env.since }}
           REPOS: ${{ github.event.inputs.repos }}

--- a/.github/workflows/generate-metrics.yml
+++ b/.github/workflows/generate-metrics.yml
@@ -24,10 +24,22 @@ jobs:
       issues: write
       contents: write
       pull-requests: read
+      id-token: write # required for the Octo STS OIDC exchange
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Obtain Octo STS token
+        # Mints a short-lived, org-wide read token (replacing a long-lived PAT)
+        # to read workflow runs, pull requests and commits across the team repos
+        # listed in the manifests. Requires the org-level trust policy in
+        # ministryofjustice/.github (.github/chainguard/ministryofjustice-dora-the-explora.sts.yaml).
+        id: octo_sts
+        uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        with:
+          scope: ministryofjustice
+          identity: ministryofjustice-dora-the-explora
 
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -56,7 +68,7 @@ jobs:
 
       - name: Run scripts and create issues
         env:
-          ACCESS_TOKEN: ${{ secrets.DATA_PLATFORM_ROBOT_PAT }}
+          ACCESS_TOKEN: ${{ steps.octo_sts.outputs.token }}
           GH_TOKEN: ${{ github.token }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           JSON_FILE_PATH: ${{ github.event.inputs.json_file_path }}

--- a/.github/workflows/mpe-dora.yml
+++ b/.github/workflows/mpe-dora.yml
@@ -23,11 +23,22 @@ jobs:
     permissions:
       issues: write
       contents: read
+      id-token: write # required for the Octo STS OIDC exchange
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Obtain Octo STS token
+        # Mints a short-lived token to read modernisation-platform-environments,
+        # replacing a long-lived PAT. Requires a trust policy in that repo at
+        # .github/chainguard/ministryofjustice-dora-the-explora.sts.yaml.
+        id: octo_sts
+        uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        with:
+          scope: ministryofjustice/modernisation-platform-environments
+          identity: ministryofjustice-dora-the-explora
 
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -47,7 +58,7 @@ jobs:
 
       - name: Run MPE DORA and create an issue
         env:
-          ACCESS_TOKEN: ${{ secrets.DATA_PLATFORM_ROBOT_PAT }}
+          ACCESS_TOKEN: ${{ steps.octo_sts.outputs.token }}
           GH_TOKEN: ${{ github.token }}
           SINCE: ${{ env.since }}
           APPS: ${{ github.event.inputs.apps }}

--- a/.github/workflows/mpe-dora.yml
+++ b/.github/workflows/mpe-dora.yml
@@ -31,13 +31,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Obtain Octo STS token
-        # Mints a short-lived token to read modernisation-platform-environments,
-        # replacing a long-lived PAT. Requires a trust policy in that repo at
-        # .github/chainguard/ministryofjustice-dora-the-explora.sts.yaml.
+        # Mints a short-lived, org-wide read token (replacing a long-lived PAT)
+        # to read modernisation-platform-environments deployments. Uses the org
+        # scope so it resolves the org-level trust policy in ministryofjustice/.github
+        # (.github/chainguard/ministryofjustice-dora-the-explora.sts.yaml).
         id: octo_sts
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         with:
-          scope: ministryofjustice/modernisation-platform-environments
+          scope: ministryofjustice
           identity: ministryofjustice-dora-the-explora
 
       - name: Set up uv


### PR DESCRIPTION
## Summary

Replaces the long-lived `DATA_PLATFORM_ROBOT_PAT` with short-lived, OIDC-minted **Octo STS** tokens across **all three** DORA workflows:

| Workflow | Reads | octo-sts scope | Trust policy |
|---|---|---|---|
| `mpe-dora.yml` | `modernisation-platform-environments` only | `ministryofjustice` (org) | org-level |
| `generate-metrics.yml` | 28 team-manifest repos | `ministryofjustice` (org) | org-level |
| `cp-dora.yml` | `cloud-platform-environments` + ~150 tenant repos | `ministryofjustice` (org) | org-level |

Each adds `id-token: write` and consumes `steps.octo_sts.outputs.token` as `ACCESS_TOKEN`. `octo-sts/action` is SHA-pinned to v1.1.1.

## Depends on

**ministryofjustice/.github#52** — the org-level trust policy. Verified against the octo-sts source: a bare `scope: ministryofjustice` (no slash) makes the app read an **org-level** policy from `ministryofjustice/.github` at `.github/chainguard/ministryofjustice-dora-the-explora.sts.yaml`. That policy:

- pins `subject_pattern` to `dora-the-explora`'s **main branch** (PRs/forks can't mint);
- grants read-only `contents` + `deployments` + `actions` + `pull_requests` (covers all four metric scripts + the deployment tools);
- omits `repositories:` → org-wide read (intentional; the CP cohort is dynamic).

**These workflows will fail to mint a token until #52 merges.**

## ⚠️ Known risk — CP code search

`cp_dora.py` enumerates tenant repos via the **code search API** (`GET /search/code`). GitHub **App installation tokens** (which Octo STS mints) may not be permitted to call code search. This must be verified on the first `workflow_dispatch` run of `cp-dora.yml`. If it fails, CP enumeration needs either a non-code-search fallback (walk the `cloud-platform-environments` tree) or use of the `--repos` input. MPE and generate-metrics do not use code search and are unaffected.

## Verification plan

The OIDC exchange can't be tested locally. After #52 merges, `workflow_dispatch` each workflow (start with MPE — simplest) and confirm the token mints and the API calls succeed before relying on the scheduled crons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)